### PR TITLE
update blockchain_manager to make it safer

### DIFF
--- a/source/src/mods/PoA/blockchain_manager.rs
+++ b/source/src/mods/PoA/blockchain_manager.rs
@@ -52,10 +52,12 @@ pub fn block_generate() {
                 next_index = 0;
             }
             for c in CONNECTION_LIST.iter() {
-                c.write(format!(
-                    "{{\"type\":\"block\",\"args\":{{\"block\":{}}}}}\r\n",
-                    BLOCKCHAIN[BLOCKCHAIN.len() - 1].dump()
-                ));
+                if BLOCKCHAIN.len() > 0 {
+                    c.write(format!(
+                        "{{\"type\":\"block\",\"args\":{{\"block\":{}}}}}\r\n",
+                        BLOCKCHAIN[BLOCKCHAIN.len() - 1].dump()
+                    ));
+                }
             }
             //算出された次の生成車は自分か
             if TRUSTED_KEY


### PR DESCRIPTION
blockchain_manager:54のforはブロックが一つも生成されていない場合にアクセスしてしまうとindexがオーバーフローする可能性がありました。
このマージでその問題を解決します