### PR TITLE
Dev

### DIFF
--- a/source/src/main.rs
+++ b/source/src/main.rs
@@ -75,4 +75,5 @@ pub fn access_test() {
     thread::sleep(Duration::from_secs(1));
     println!("finish:{}", TESTARRAY.lock().unwrap()[0].num);
     println!("finish:{}", TESTARRAY.lock().unwrap()[0].num);
+    println!("leng:{}", TESTARRAY.lock().unwrap().len());
 }

--- a/source/src/main.rs
+++ b/source/src/main.rs
@@ -18,7 +18,6 @@ mod mods;
 
 ラウンドロビンでは、過去のブロックを改ざんするには、全員の秘密鍵を入手しないとブロックを繋げられない。<br />
 ネイティブ通貨の概念が存在しないため、ローカルブロックの読み込みは順番とハッシュの繋がりのチェックだけ行う。<br />
-TODO: 起動時の最新出ないノードリストをすべて表示するようにする
 TODO: ブロックのシェア<br />
 TODO: ブロック＆トランザクションのモジュールディレクトリの整形<br />
 TODO: ノード間TLS通信<br />
@@ -36,6 +35,7 @@ fn main() {
     println(format!("[main]thread-Inited"));
     dns_seed::init();
     println(format!("[main]Inited"));
+    thread::spawn(|| connection::ovserve());
     loop {
         let line = &mut String::new();
         let size = stdin().read_line(line).unwrap();
@@ -43,37 +43,4 @@ fn main() {
             println(format!("[main]your input:{}", line));
         }
     }
-}
-struct TEST {
-    pub num: isize,
-}
-impl Clone for TEST {
-    fn clone(&self) -> TEST {
-        TEST { num: self.num }
-    }
-}
-impl TEST {
-    pub fn test_th(&self) {
-        println!("num:{}", TESTARRAY.lock().unwrap()[0].num);
-        TESTARRAY.lock().unwrap()[0].num = 50;
-    }
-}
-static TESTARRAY: Lazy<Mutex<Vec<TEST>>> = Lazy::new(|| Mutex::new(Vec::new()));
-#[test]
-pub fn numeric_convert() {
-    let i: isize = 10;
-    let u: usize = i as usize;
-    assert!(u == 10);
-    let i = u as isize;
-    assert!(i == 10)
-}
-#[test]
-pub fn access_test() {
-    let test = TEST { num: -1 };
-    TESTARRAY.lock().unwrap().push(test.clone());
-    thread::spawn(move || test.test_th());
-    thread::sleep(Duration::from_secs(1));
-    println!("finish:{}", TESTARRAY.lock().unwrap()[0].num);
-    println!("finish:{}", TESTARRAY.lock().unwrap()[0].num);
-    println!("leng:{}", TESTARRAY.lock().unwrap().len());
 }

--- a/source/src/mods/PoA/blockchain_manager.rs
+++ b/source/src/mods/PoA/blockchain_manager.rs
@@ -6,7 +6,7 @@ use crate::mods::certification::key_agent::SECRET;
 use crate::mods::certification::sign_util::{create_sign, SECP, TRUSTED_KEY};
 use crate::mods::config::config::YAML;
 use crate::mods::console::output::{eprintln, println};
-use crate::mods::network::connection::CONNECTION_LIST;
+use crate::mods::network::connection::Connection;
 use crate::mods::{
     certification::{key_agent, sign_util},
     network::connection,
@@ -51,7 +51,12 @@ pub fn block_generate() {
             } else {
                 next_index = 0;
             }
-            for c in CONNECTION_LIST.iter() {
+            for c in connection::STATS
+                .write()
+                .unwrap()
+                .connection_list
+                .iter_mut()
+            {
                 if BLOCKCHAIN.read().unwrap().len() > 0 {
                     c.write(format!(
                         "{{\"type\":\"block\",\"args\":{{\"block\":{}}}}}\r\n",
@@ -131,7 +136,12 @@ pub fn block_generate() {
                         next_index = 0;
                     }
                     println(format!("[blockchain_manager]next generator:{}", next_index));
-                    for c in CONNECTION_LIST.iter() {
+                    for c in connection::STATS
+                        .write()
+                        .unwrap()
+                        .connection_list
+                        .iter_mut()
+                    {
                         c.write(format!(
                             "{{\"type\":\"block\",\"args\":{{\"block\":{}}}}}\r\n",
                             block.dump()

--- a/source/src/mods/block/block.rs
+++ b/source/src/mods/block/block.rs
@@ -10,6 +10,7 @@ use secp256k1::{Message, SecretKey};
 use std::fs::{self, File};
 use std::io::prelude::*;
 use std::ops::IndexMut;
+use std::sync::{Mutex, RwLock};
 use std::{
     fs::OpenOptions,
     io::{BufRead, BufReader},
@@ -29,7 +30,7 @@ use crate::mods::{
 pub static GENESIS_BLOCK_HASH: &str =
     "3F6D388DB566932F70F35D15D9FA88822F40075BDAAA370CCB40536D2FC18C3D";
 pub static TX_PER_FILE: usize = 100;
-pub static mut BLOCKCHAIN: Lazy<Vec<JsonValue>> = Lazy::new(|| Vec::new());
+pub static BLOCKCHAIN: Lazy<RwLock<Vec<JsonValue>>> = Lazy::new(|| RwLock::new(Vec::new()));
 
 pub fn check(block: JsonValue, previous_hash: String) -> bool {
     println(format!("[block]dumped_full_block:{}", block.dump()));
@@ -132,7 +133,7 @@ pub fn read_block_from_local() {
                 last_block_height = _block["height"].as_usize().unwrap();
                 println(format!("[block]height:{}", last_block_height));
                 unsafe {
-                    BLOCKCHAIN.push(_block);
+                    BLOCKCHAIN.write().unwrap().push(_block);
                 }
             }
         }
@@ -143,7 +144,7 @@ pub fn read_block_from_local() {
                 if TRUSTED_KEY
                     .get(&(i as isize))
                     .unwrap()
-                    .eq(&BLOCKCHAIN[BLOCKCHAIN.len() - 1]["author"])
+                    .eq(&BLOCKCHAIN.read().unwrap()[BLOCKCHAIN.read().unwrap().len() - 1]["author"])
                 {
                     set_previous_generator(i as isize);
                     break;

--- a/source/src/mods/network/connection.rs
+++ b/source/src/mods/network/connection.rs
@@ -19,13 +19,25 @@ use std::net::Shutdown;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::sync::RwLock;
 use std::thread;
 use std::time::Duration;
 use std::{io::BufReader, net::TcpStream};
 static COUNT: Lazy<Mutex<u16>> = Lazy::new(|| Mutex::new(0));
-pub static mut CONNECTION_LIST: Lazy<Vec<Connection>> = Lazy::new(|| Vec::new());
 pub static IS_BLOCKED: Lazy<Mutex<bool>> = Lazy::new(|| Mutex::new(false));
-
+/**
+ * 重複するノード・接続終了したノードの削除ループの実装
+ * */
+pub struct ConnectionStats {
+    pub connection_list: Vec<Connection>,
+    pub count: u16,
+}
+pub static STATS: Lazy<RwLock<ConnectionStats>> = Lazy::new(|| {
+    RwLock::new(ConnectionStats {
+        connection_list: Vec::new(),
+        count: 0,
+    })
+});
 pub struct Connection {
     pub is_connected: bool, //処理中などにノードが使用不可になったことを判定できるようにisokは必要
     pub id: u16,
@@ -49,218 +61,183 @@ impl Clone for Connection {
     }
 }
 impl Connection {
-    pub fn read_thread(&self) {
-        let mut reader = BufReader::new(&*self.stream);
+    pub fn read_thread(&mut self) {
+        let binding = (&self.stream).clone();
+        let mut reader = BufReader::new(&*binding);
         loop {
             let mut line = String::new();
             let bytes = reader.read_line(&mut line).unwrap();
-            if bytes == 0 || !self.is_connected {
-                println(format!("[connection]接続終了"));
-                unsafe {
-                    CONNECTION_LIST.remove(get_idx(self.id));
-                }
+            if bytes == 0 || line.trim().len() == 0 {
+                self.is_connected = false;
+                self.stream.shutdown(Shutdown::Both).unwrap();
                 break;
-            } else {
-                println(format!("[connection]read_line{}", line));
-                let json_obj = json::parse(&line).unwrap();
-                if json_obj["type"].eq("hello") {
-                    println(format!(
-                        "[connection]received pubk is {}",
-                        json_obj["args"]["pubk"].to_string()
+            }
+            println(format!("[connection]read_line{}", line));
+            let json_obj = json::parse(&line).unwrap();
+            if json_obj["type"].eq("hello") {
+                println(format!(
+                    "[connection]received pubk is {}",
+                    json_obj["args"]["pubk"].to_string()
+                ));
+                self.pubk = Option::Some(
+                    PublicKey::from_str(json_obj["args"]["pubk"].as_str().unwrap())
+                        .unwrap()
+                        .clone(),
+                );
+
+                if sign_util::is_host_trusted(self.pubk.unwrap().to_string()) {
+                    let mut rng = rand::thread_rng();
+                    let generated_rand = rng.next_u32();
+                    self.write(format!(
+                        "{{\"type\":\"req_sign\",\"args\":{{\"nonce\":\"{}\"}}}}\r\n",
+                        generated_rand
                     ));
-                    let mut is_already_connected = false;
-                    unsafe {
-                        for c in CONNECTION_LIST.iter() {
-                            if c.pubk.is_some() {
-                                if c.pubk
-                                    .unwrap()
-                                    .to_string()
-                                    .eq(&json_obj["args"]["pubk"].to_string())
-                                {
-                                    self.stream.shutdown(Shutdown::Both).unwrap();
-                                    CONNECTION_LIST[get_idx(self.id)].is_connected = false;
-                                    is_already_connected = true;
-                                    break;
-                                }
-                            }
-                        }
-                        if !is_already_connected {
-                            CONNECTION_LIST[get_idx(self.id)].pubk = Option::Some(
-                                PublicKey::from_str(json_obj["args"]["pubk"].as_str().unwrap())
-                                    .unwrap()
-                                    .clone(),
-                            );
 
-                            if sign_util::is_host_trusted(
-                                CONNECTION_LIST[get_idx(self.id)].pubk.unwrap().to_string(),
-                            ) {
-                                let mut rng = rand::thread_rng();
-                                let generated_rand = rng.next_u32();
-                                self.write(format!(
-                                    "{{\"type\":\"req_sign\",\"args\":{{\"nonce\":\"{}\"}}}}\r\n",
-                                    generated_rand
-                                ));
+                    self.nonce = Option::Some(format!("{}", generated_rand));
+                } else {
+                    wprintln(format!(
+                        "[connection]connection not trusted for wrong pubk."
+                    ));
+                }
+            } else if json_obj["type"].eq("req_sign") {
+                unsafe {
+                    let sign = sign_util::create_sign(
+                        json_obj["args"]["nonce"].as_str().unwrap().to_string(),
+                        key_agent::SECRET[0],
+                    );
+                    self.write(format!(
+                        "{{\"type\":\"signed\",\"args\":{{\"sign\":\"{}\"}}}}\r\n",
+                        sign.to_string()
+                    ));
+                    println(format!("[connection]sign was sent"));
+                }
+            } else if json_obj["type"].eq("signed") {
+                let verify_result;
+                verify_result = sign_util::verify_sign(
+                    self.nonce.clone().unwrap(),
+                    json_obj["args"]["sign"].as_str().unwrap().to_string(),
+                    self.pubk.unwrap(),
+                );
 
-                                CONNECTION_LIST[get_idx(self.id)].nonce =
-                                    Option::Some(format!("{}", generated_rand));
-                            } else {
-                                wprintln(format!(
-                                    "[connection]connection not trusted for wrong pubk."
-                                ));
-                            }
-                        }
-                    }
-                } else if json_obj["type"].eq("req_sign") {
-                    unsafe {
-                        let sign = sign_util::create_sign(
-                            json_obj["args"]["nonce"].as_str().unwrap().to_string(),
-                            key_agent::SECRET[0],
-                        );
-                        self.write(format!(
-                            "{{\"type\":\"signed\",\"args\":{{\"sign\":\"{}\"}}}}\r\n",
-                            sign.to_string()
+                if verify_result {
+                    println(format!("[connection]verifying connection success"));
+                    self.is_trusted = true;
+                    println(format!(
+                        "[connection]is trusted:{}",
+                        self.is_trusted.to_string()
+                    ));
+                    self.write("{\"type\":\"get_latest\"}\r\n".to_string());
+
+                //すべてのノードに最新のブロックを問い合わせて、最新状態に同期する。
+                } else {
+                    wprintln(format!("[connection]failed to verify this connection"));
+                }
+            } else if json_obj["type"].eq("get_latest") {
+                if BLOCKCHAIN.read().unwrap().len() > 0 {
+                    self.write(format!(
+                        "{{\"type\":\"block\",\"args\":{{\"block\":{}}}}}\r\n",
+                        BLOCKCHAIN.read().unwrap()[BLOCKCHAIN.read().unwrap().len() - 1].dump()
+                    ));
+                } else {
+                    self.write("{\"type\":\"no_block\"}\r\n".to_string());
+                }
+            } else if json_obj["type"].eq("block") {
+                unsafe {
+                    if !*IS_BLOCKED.lock().unwrap() {
+                        *IS_BLOCKED.lock().unwrap() = true;
+
+                        println(format!(
+                            "[connection]BLOCKCHAIN_LEN:{}",
+                            BLOCKCHAIN.read().unwrap().len()
                         ));
-                        println(format!("[connection]sign was sent"));
-                    }
-                } else if json_obj["type"].eq("signed") {
-                    let verify_result;
-                    unsafe {
-                        verify_result = sign_util::verify_sign(
-                            CONNECTION_LIST[get_idx(self.id)].nonce.clone().unwrap(),
-                            json_obj["args"]["sign"].as_str().unwrap().to_string(),
-                            CONNECTION_LIST[get_idx(self.id)].pubk.unwrap(),
-                        );
-                    }
-                    if verify_result {
-                        println(format!("[connection]verifying connection success"));
-                        unsafe {
-                            CONNECTION_LIST[get_idx(self.id)].is_trusted = true;
-                        }
-                        unsafe {
-                            println(format!(
-                                "[connection]is trusted:{}",
-                                CONNECTION_LIST[get_idx(self.id)].is_trusted.to_string()
-                            ));
-                            CONNECTION_LIST[get_idx(self.id)]
-                                .write("{\"type\":\"get_latest\"}\r\n".to_string());
-                        }
-
-                    //すべてのノードに最新のブロックを問い合わせて、最新状態に同期する。
-                    } else {
-                        wprintln(format!("[connection]failed to verify this connection"));
-                    }
-                } else if json_obj["type"].eq("get_latest") {
-                    unsafe {
-                        if BLOCKCHAIN.read().unwrap().len() > 0 {
-                            self.write(format!(
-                                "{{\"type\":\"block\",\"args\":{{\"block\":{}}}}}\r\n",
-                                BLOCKCHAIN.read().unwrap()[BLOCKCHAIN.read().unwrap().len() - 1]
-                                    .dump()
-                            ));
-                        } else {
-                            self.write("{\"type\":\"no_block\"}\r\n".to_string());
-                        }
-                    }
-                } else if json_obj["type"].eq("block") {
-                    unsafe {
-                        if !*IS_BLOCKED.lock().unwrap() {
-                            *IS_BLOCKED.lock().unwrap() = true;
-
-                            println(format!(
-                                "[connection]BLOCKCHAIN_LEN:{}",
-                                BLOCKCHAIN.read().unwrap().len()
-                            ));
-                            println(format!(
-                                "[connection]received height:{}",
-                                json_obj["args"]["block"]["height"].as_usize().unwrap()
-                            ));
-                            if json_obj["args"]["block"]["height"].as_usize().unwrap()
-                                > BLOCKCHAIN.read().unwrap().len()
-                            {
-                                let previous = match BLOCKCHAIN.read().unwrap().len() > 0 {
-                                    true => Message::from_hashed_data::<sha256::Hash>(
-                                        BLOCKCHAIN.read().unwrap()
-                                            [BLOCKCHAIN.read().unwrap().len() - 1]
-                                            .dump()
-                                            .as_bytes(),
-                                    )
-                                    .to_string(),
-                                    false => block::GENESIS_BLOCK_HASH.to_string(),
-                                };
-                                if check(json_obj["args"]["block"].clone(), previous) {
-                                    println(format!(
+                        println(format!(
+                            "[connection]received height:{}",
+                            json_obj["args"]["block"]["height"].as_usize().unwrap()
+                        ));
+                        if json_obj["args"]["block"]["height"].as_usize().unwrap()
+                            > BLOCKCHAIN.read().unwrap().len()
+                        {
+                            let previous = match BLOCKCHAIN.read().unwrap().len() > 0 {
+                                true => Message::from_hashed_data::<sha256::Hash>(
+                                    BLOCKCHAIN.read().unwrap()
+                                        [BLOCKCHAIN.read().unwrap().len() - 1]
+                                        .dump()
+                                        .as_bytes(),
+                                )
+                                .to_string(),
+                                false => block::GENESIS_BLOCK_HASH.to_string(),
+                            };
+                            if check(json_obj["args"]["block"].clone(), previous) {
+                                println(format!(
                                 "[connection]Received block is correct and taller than my block"
                             ));
-                                    for i in 0..TRUSTED_KEY.len() {
-                                        println(format!(
-                                            "[connection]compare trusted_key:{} and {}",
-                                            TRUSTED_KEY.get(&(i as isize)).unwrap(),
-                                            &json_obj["args"]["block"]["author"].to_string()
-                                        ));
-                                        if TRUSTED_KEY
-                                            .get(&(i as isize))
-                                            .unwrap()
-                                            .eq(&json_obj["args"]["block"]["author"].to_string())
-                                        {
-                                            set_previous_generator(i as isize);
-                                            break;
-                                        }
-                                    }
+                                for i in 0..TRUSTED_KEY.len() {
                                     println(format!(
-                                        "[connection]previous_generator:{}",
-                                        get_previous_generator()
+                                        "[connection]compare trusted_key:{} and {}",
+                                        TRUSTED_KEY.get(&(i as isize)).unwrap(),
+                                        &json_obj["args"]["block"]["author"].to_string()
                                     ));
-                                    BLOCKCHAIN
-                                        .write()
+                                    if TRUSTED_KEY
+                                        .get(&(i as isize))
                                         .unwrap()
-                                        .push(json_obj["args"]["block"].clone());
-                                    println("[connection]New block pushed to my blockchain");
-                                } else if check(json_obj["args"]["block"].clone(), "*".to_string())
-                                {
-                                    println(format!(
+                                        .eq(&json_obj["args"]["block"]["author"].to_string())
+                                    {
+                                        set_previous_generator(i as isize);
+                                        break;
+                                    }
+                                }
+                                println(format!(
+                                    "[connection]previous_generator:{}",
+                                    get_previous_generator()
+                                ));
+                                BLOCKCHAIN
+                                    .write()
+                                    .unwrap()
+                                    .push(json_obj["args"]["block"].clone());
+                                println("[connection]New block pushed to my blockchain");
+                            } else if check(json_obj["args"]["block"].clone(), "*".to_string()) {
+                                println(format!(
                                         "[connection]Received block is correct but it taller than my blockchain for 2 or more."
                                     ));
-                                } else {
-                                    wprintln(format!("[connection]Received block is taller than my block but not correct"));
-                                }
                             } else {
-                                wprintln(format!(
-                                    "[connection]Received block is not taller than my block."
-                                ));
+                                wprintln(format!("[connection]Received block is taller than my block but not correct"));
                             }
-                            *IS_BLOCKED.lock().unwrap() = false;
                         } else {
-                            println("[connection]_blocked thread.")
+                            wprintln(format!(
+                                "[connection]Received block is not taller than my block."
+                            ));
                         }
+                        *IS_BLOCKED.lock().unwrap() = false;
+                    } else {
+                        println("[connection]_blocked thread.")
                     }
-                    unsafe {
-                        CONNECTION_LIST[get_idx(self.id)].is_latest = true;
-                    }
-                } else if json_obj["type"].eq("no_block") {
-                    unsafe {
-                        CONNECTION_LIST[get_idx(self.id)].is_latest = true;
-                    }
-                } else {
-                    wprintln(format!("[connection]connection received unknown command"));
                 }
+                self.is_latest = true;
+            } else if json_obj["type"].eq("no_block") {
+                self.is_latest = true;
+            } else {
+                wprintln(format!("[connection]connection received unknown command"));
             }
         }
     }
-    pub fn write(&self, context: String) {
+    pub fn write(&mut self, context: String) {
         if self.is_connected {
-            loop {
-                if !*IS_BLOCKED.lock().unwrap() {
-                    break;
+            match (&*self.stream).write_all(context.as_bytes()) {
+                Err(e) => {
+                    self.is_connected = false;
                 }
-                println("[connection]blocking thread");
-                thread::sleep(Duration::from_secs(1));
-            }
-            (&*self.stream).write_all(context.as_bytes()).unwrap();
-            (&*self.stream).flush().unwrap();
+                Ok(o) => {}
+            };
+            match (&*self.stream).flush() {
+                Err(e) => {
+                    self.is_connected = false;
+                }
+                Ok(o) => {}
+            };
         }
     }
 }
-/*pub fn is_all_connected() -> bool {
+/**pub fn is_all_connected() -> bool {
     unsafe {
         for tk in sign_util::TRUSTED_KEY.values() {
             if !tk.eq(config::YAML["docker"]["own-pubk"].as_str().unwrap()) {
@@ -283,15 +260,36 @@ impl Connection {
         return true;
     }
 }*/
-fn get_idx(id: u16) -> usize {
-    unsafe {
-        for idx in 0..CONNECTION_LIST.len() {
-            if CONNECTION_LIST[idx].id == id {
-                return idx;
+pub fn ovserve() {
+    loop {
+        let mut _stats = STATS.write().unwrap();
+        let len = _stats.connection_list.len();
+        let mut rem: Vec<usize> = Vec::new();
+        for i in 0.._stats.connection_list.len() {
+            if !_stats.connection_list[i].is_connected {
+                rem.push(i);
             }
         }
-        CONNECTION_LIST.len()
+        for i in rem {
+            _stats.connection_list.remove(i);
+        }
+        let after_len = _stats.connection_list.len();
+        drop(_stats);
+        println(format!(
+            "[connection]connection_list's gabage collacted:{}->{}",
+            len, after_len
+        ));
+        thread::sleep(Duration::from_secs(12));
     }
+}
+fn get_idx(id: u16) -> usize {
+    let stats_r = STATS.read().unwrap();
+    for idx in 0..stats_r.connection_list.len() {
+        if stats_r.connection_list[idx].id == id {
+            return idx;
+        }
+    }
+    stats_r.connection_list.len()
 }
 pub fn init(stream: Arc<TcpStream>) -> Connection {
     *COUNT.lock().unwrap() += 1;

--- a/source/src/mods/network/connection_listener.rs
+++ b/source/src/mods/network/connection_listener.rs
@@ -1,6 +1,5 @@
 use super::super::config::config::YAML;
 use super::connection;
-use super::connection::CONNECTION_LIST;
 use crate::mods::console::output::{eprintln, println};
 use std::net::TcpListener;
 use std::sync::Arc;
@@ -20,11 +19,13 @@ pub fn run() {
     for streams in listener.incoming() {
         println(format!("[connection_listener]connection incoming!"));
         let streams = streams.unwrap();
-        unsafe {
-            let user = connection::init(Arc::new(streams));
-            let user2 = user.clone();
-            CONNECTION_LIST.push(user);
-            thread::spawn(move || user2.read_thread());
-        }
+        let user = connection::init(Arc::new(streams));
+        let mut user2 = user.clone();
+        connection::STATS
+            .write()
+            .unwrap()
+            .connection_list
+            .push(user);
+        thread::spawn(move || user2.read_thread());
     }
 }

--- a/source/src/mods/network/dns_seed.rs
+++ b/source/src/mods/network/dns_seed.rs
@@ -1,7 +1,6 @@
 #![feature(catch_expr)]
 use super::super::config::config;
 use super::connection;
-use super::connection::CONNECTION_LIST;
 use crate::mods::console::output::{eprintln, println, wprintln};
 use once_cell::sync::Lazy;
 use std::net::Ipv4Addr;
@@ -73,7 +72,11 @@ pub fn init() {
                 let mut _user2 = _user.clone();
                 thread::spawn(move || _user2.read_thread());
                 unsafe {
-                    CONNECTION_LIST.push(_user);
+                    connection::STATS
+                        .write()
+                        .unwrap()
+                        .connection_list
+                        .push(_user);
                 }
             }
             //↑dockerが同時に立ち上がり、listeningしていないときに接続を試みることを防ぐため、名前に合わせて数秒待つ
@@ -112,7 +115,11 @@ pub fn init() {
             let mut _user2 = _user.clone();
             thread::spawn(move || _user2.read_thread());
             unsafe {
-                CONNECTION_LIST.push(_user);
+                connection::STATS
+                    .write()
+                    .unwrap()
+                    .connection_list
+                    .push(_user);
             }
         }
     }


### PR DESCRIPTION
Connection_list is thread safe now
デッドロックを回避するため、connectionに原子性をもたせました。具体的にはグローバル変数は一つのSTATSという変数にまとめられ、ロックが成功するか失敗し、待つかの2パターンになったことでデッドロックを回避しています。
ただし、STATSをロックしている間、他のスレッドは待機する必要がるため、パフォーマンスに多少影響を与える可能性があります。